### PR TITLE
User can delete search results from their search history

### DIFF
--- a/GivHub-Angular/src/app/components/search-history/search-history.component.html
+++ b/GivHub-Angular/src/app/components/search-history/search-history.component.html
@@ -4,8 +4,9 @@
             <th scope="col">Search Phrase</th>
         </thead>
         <tbody>
-            <tr *ngFor="let searchHistory of usersh;">
+            <tr [id] = "searchHistory.phrase"*ngFor="let searchHistory of usersh;">
                 <td>{{searchHistory.phrase}}</td>
+                <td><button class="btn btn-danger" *ngIf="!anotherUser" (click)="removeResult(searchHistory.phrase)">Remove</button ></td>
             </tr>
         </tbody>
     </table>

--- a/GivHub-Angular/src/app/components/search-history/search-history.component.ts
+++ b/GivHub-Angular/src/app/components/search-history/search-history.component.ts
@@ -17,6 +17,7 @@ interface Claim {
 })
 export class SearchHistoryComponent implements OnInit {
   email: string;
+  phrase: string;
   searchHistory: searchHistory;
   usersh: searchHistory[] = [];
   constructor(public oktaAuth: OktaAuthService, private router: Router, 
@@ -34,4 +35,19 @@ export class SearchHistoryComponent implements OnInit {
     )
   }
 
+  onSubmit(event: any): void{
+    
+  }
+  removeResult(phrase: string): void{
+    (<HTMLInputElement>document.getElementById(phrase)).remove();
+    this.searchHistory = {
+      email: this.email,
+      phrase: this.phrase
+    }
+    this.charityRESTService.UserRemoveSearchResult(this.email,phrase).subscribe(
+      (sub) => {
+        alert(`${phrase} was removed from your search history.`);
+      }
+    );
+  }
 }

--- a/GivHub-Angular/src/app/services/charity-rest.service.ts
+++ b/GivHub-Angular/src/app/services/charity-rest.service.ts
@@ -95,6 +95,10 @@ export class CharityRESTService {
     return this.http.post<searchHistory>(this.searchHistoryURL,sh,this.httpOptions);
   }
 
+  UserRemoveSearchResult(userEmail: string, phrase: string): Observable<searchHistory>{
+    return this.http.delete<searchHistory>(`${this.searchHistoryURL}/${userEmail},${phrase}`,this.httpOptions);
+  }
+
   GetMostDonations(): Observable<donation[]>{
     return this.http.get<donation[]>(`${this.donationURL}/topdonations`, this.httpOptions);
   }


### PR DESCRIPTION
Users now have a remove button associated with each of their searches in their search history, which when pressed permanently deletes the search from the database